### PR TITLE
Add fundamentals normalisation and scoring module

### DIFF
--- a/core/data/fundamentals.py
+++ b/core/data/fundamentals.py
@@ -1,0 +1,140 @@
+"""Utilities to normalise fundamental data returned by yfinance."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping
+
+import numpy as np
+
+__all__ = ["read_fundamentals"]
+
+
+_FUNDAMENTAL_KEYS = [
+    "roe",
+    "roa",
+    "grossMargin",
+    "operatingMargin",
+    "ebitdaMargin",
+    "revenueGrowth",
+    "earningsGrowth",
+    "trailingPE",
+    "forwardPE",
+    "pb",
+    "enterpriseToEbitda",
+    "debtToEquity",
+    "totalDebt",
+    "totalCash",
+    "currentRatio",
+    "dividendYield",
+    "payoutRatio",
+    "beta",
+    "marketCap",
+    "averageVolume",
+]
+
+
+def read_fundamentals(info: Mapping[str, object] | None) -> Dict[str, float]:
+    """Return a normalised dictionary of fundamental metrics.
+
+    The function defensively coerces values to floats and replaces missing
+    or invalid entries with ``numpy.nan``. Only a curated list of attributes
+    is extracted to keep the downstream scoring logic deterministic.
+    """
+
+    if info is None:
+        return {key: np.nan for key in _FUNDAMENTAL_KEYS}
+
+    result: Dict[str, float] = {}
+    for key in _FUNDAMENTAL_KEYS:
+        raw_value = info.get(key) if isinstance(info, Mapping) else None
+        result[key] = _coerce_numeric(raw_value)
+    return result
+
+
+def _coerce_numeric(value: object) -> float:
+    """Best-effort conversion of *value* to a float.
+
+    Numbers are returned as ``float``. Strings are parsed while supporting
+    typical yfinance formatting quirks such as percentage suffixes and
+    magnitude abbreviations (``1.2B``). Anything that cannot be safely
+    interpreted is converted to ``numpy.nan``.
+    """
+
+    if value is None:
+        return float("nan")
+
+    if isinstance(value, bool):
+        return float(value)
+
+    if isinstance(value, (int, float, np.number)):
+        if np.isnan(value):  # type: ignore[arg-type]
+            return float("nan")
+        return float(value)
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return float("nan")
+        return _coerce_numeric(value[0])
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return float("nan")
+
+        lowered = text.lower()
+        if lowered in {"nan", "n/a", "na", "none", "null", "-"}:
+            return float("nan")
+
+        multiplier = 1.0
+        if text.endswith("%"):
+            text = text[:-1]
+            multiplier = 0.01
+
+        unit_multipliers = {"k": 1e3, "m": 1e6, "b": 1e9, "t": 1e12}
+        last_char = text[-1].lower()
+        if last_char in unit_multipliers and _is_numeric_prefix(text[:-1]):
+            multiplier *= unit_multipliers[last_char]
+            text = text[:-1]
+
+        cleaned = _clean_numeric_string(text)
+        if cleaned is None:
+            return float("nan")
+
+        try:
+            parsed = float(cleaned)
+        except ValueError:
+            return float("nan")
+        return parsed * multiplier
+
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _clean_numeric_string(text: str) -> str | None:
+    allowed = set("0123456789+-.eE")
+    cleaned_chars = [ch for ch in text if ch in allowed]
+    if not cleaned_chars:
+        return None
+
+    cleaned = "".join(cleaned_chars)
+    if cleaned.count(".") > 1:
+        return None
+    if cleaned.count("e") + cleaned.count("E") > 1:
+        return None
+    return cleaned
+
+
+def _is_numeric_prefix(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return False
+    cleaned = _clean_numeric_string(stripped)
+    if cleaned is None:
+        return False
+    try:
+        float(cleaned)
+    except ValueError:
+        return False
+    return True

--- a/core/scoring.py
+++ b/core/scoring.py
@@ -1,0 +1,289 @@
+"""Scoring helpers combining fundamentals and technical timing."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Tuple
+
+import numpy as np
+import pandas as pd
+
+from core.indicators import rsi, sma, vol_ma
+
+__all__ = [
+    "zscore_mad",
+    "score_quality",
+    "score_growth",
+    "score_value",
+    "score_finance",
+    "score_dividend",
+    "composite",
+    "timing_modifier",
+]
+
+
+def zscore_mad(values: Iterable[float] | pd.Series) -> pd.Series:
+    """Return the median-absolute-deviation based z-score of *values*."""
+
+    series = pd.Series(list(values) if not isinstance(values, pd.Series) else values).astype(float)
+    if series.empty:
+        return series
+
+    median = series.median(skipna=True)
+    deviations = (series - median).abs()
+    mad = deviations.median(skipna=True)
+
+    if mad is None or np.isnan(mad) or mad == 0:
+        std = series.std(ddof=0)
+        if std == 0 or np.isnan(std):
+            return pd.Series(np.zeros(len(series)), index=series.index, dtype=float)
+        return ((series - median) / std).fillna(0.0)
+
+    scale = 0.6744897501960817  # Approximation so that MAD matches standard deviation
+    return ((series - median) * scale / mad).fillna(0.0)
+
+
+def score_quality(fundamentals: Mapping[str, float]) -> float:
+    metrics = [
+        _score_linear(fundamentals.get("roe"), 0.1, 0.25),
+        _score_linear(fundamentals.get("roa"), 0.05, 0.15),
+        _score_linear(fundamentals.get("grossMargin"), 0.25, 0.55),
+        _score_linear(fundamentals.get("operatingMargin"), 0.1, 0.3),
+        _score_linear(fundamentals.get("ebitdaMargin"), 0.15, 0.35),
+    ]
+    return _aggregate_scores(metrics)
+
+
+def score_growth(fundamentals: Mapping[str, float]) -> float:
+    metrics = [
+        _score_linear(fundamentals.get("revenueGrowth"), 0.0, 0.25),
+        _score_linear(fundamentals.get("earningsGrowth"), 0.0, 0.3),
+    ]
+    return _aggregate_scores(metrics)
+
+
+def score_value(fundamentals: Mapping[str, float]) -> float:
+    metrics = [
+        _score_linear(fundamentals.get("trailingPE"), 10.0, 40.0, reverse=True),
+        _score_linear(fundamentals.get("forwardPE"), 10.0, 35.0, reverse=True),
+        _score_linear(fundamentals.get("pb"), 1.0, 6.0, reverse=True),
+        _score_linear(fundamentals.get("enterpriseToEbitda"), 6.0, 20.0, reverse=True),
+    ]
+    return _aggregate_scores(metrics)
+
+
+def score_finance(fundamentals: Mapping[str, float]) -> float:
+    debt_to_equity = fundamentals.get("debtToEquity")
+    current_ratio = fundamentals.get("currentRatio")
+    total_debt = fundamentals.get("totalDebt")
+    total_cash = fundamentals.get("totalCash")
+
+    coverage = None
+    if _is_finite(total_debt) and total_debt > 0 and _is_finite(total_cash):
+        coverage = total_cash / total_debt
+
+    metrics = [
+        _score_linear(debt_to_equity, 0.0, 2.0, reverse=True),
+        _score_linear(current_ratio, 1.0, 3.0),
+        _score_linear(coverage, 0.25, 1.5),
+    ]
+    return _aggregate_scores(metrics)
+
+
+def score_dividend(fundamentals: Mapping[str, float]) -> float:
+    yield_score = _score_linear(fundamentals.get("dividendYield"), 0.005, 0.06)
+    payout = fundamentals.get("payoutRatio")
+    payout_score = _score_band(payout, low=0.0, sweet_low=0.3, sweet_high=0.6, high=0.9)
+    return _aggregate_scores([yield_score, payout_score])
+
+
+def composite(weights: Mapping[str, float], parts: Mapping[str, float]) -> float:
+    total_weight = sum(max(weight, 0.0) for weight in weights.values())
+    if total_weight <= 0:
+        return 0.0
+
+    accum = 0.0
+    for key, weight in weights.items():
+        part_value = parts.get(key, 0.0)
+        accum += max(weight, 0.0) * max(min(part_value, 100.0), 0.0)
+
+    result = accum / total_weight
+    return float(np.clip(result, 0.0, 100.0))
+
+
+def timing_modifier(price_df: pd.DataFrame) -> Tuple[float, str]:
+    if price_df is None or price_df.empty:
+        return 0.0, "No price data"
+
+    close_series = _column_case_insensitive(price_df, {"close", "adj close"})
+    high_series = _column_case_insensitive(price_df, {"high"})
+    volume_series = _column_case_insensitive(price_df, {"volume"})
+
+    if close_series is None or high_series is None:
+        return 0.0, "Incomplete OHLC data"
+
+    closes = close_series.dropna()
+    highs = high_series.loc[closes.index]
+
+    if closes.shape[0] < 60:
+        return 0.0, "Insufficient price history"
+
+    sma50 = sma(closes, 50)
+    sma200 = sma(closes, 200)
+    rsi_series = rsi(closes, 14)
+
+    last_close = closes.iloc[-1]
+    last_sma50 = sma50.iloc[-1]
+    last_sma200 = sma200.iloc[-1]
+    last_rsi = rsi_series.iloc[-1]
+
+    if np.isnan(last_sma200):
+        return 0.0, "Insufficient long-term trend data"
+
+    if last_close < last_sma200 * 0.995:
+        return -20.0, "Price below SMA200 regime filter"
+
+    modifier = 0.0
+    reason = "Neutral setup"
+
+    breakout_modifier, breakout_reason = _breakout_signal(closes, highs, volume_series)
+    locked_signal = False
+    if breakout_modifier is not None:
+        modifier = breakout_modifier
+        reason = breakout_reason
+        locked_signal = True
+    else:
+        pullback_modifier, pullback_reason = _pullback_signal(closes, last_sma50, last_sma200, last_rsi)
+        if pullback_modifier is not None:
+            modifier = pullback_modifier
+            reason = pullback_reason
+            locked_signal = True
+        else:
+            trend_modifier, trend_reason = _trend_bias(last_close, last_sma50, last_sma200, last_rsi)
+            modifier = trend_modifier
+            reason = trend_reason
+
+    if not locked_signal and last_rsi >= 75 and last_close > last_sma50 * 1.08:
+        modifier = -10.0
+        reason = "Extended and overbought"
+
+    return float(np.clip(modifier, -20.0, 50.0)), reason
+
+
+def _breakout_signal(
+    closes: pd.Series, highs: pd.Series, volume_series: pd.Series | None
+) -> Tuple[float | None, str]:
+    if closes.shape[0] < 40 or volume_series is None or volume_series.empty:
+        return None, ""
+
+    aligned_volume = volume_series.reindex(closes.index).ffill()
+    if aligned_volume.shape[0] < 20:
+        return None, ""
+
+    last_close = closes.iloc[-1]
+    last_volume = aligned_volume.iloc[-1]
+    recent_high = closes.rolling(window=20, min_periods=20).max().iloc[-1]
+    volume_ma = vol_ma(aligned_volume, 20).iloc[-1]
+
+    if np.isnan(recent_high) or np.isnan(volume_ma):
+        return None, ""
+
+    if last_close >= recent_high * 0.999 and last_volume >= volume_ma * 1.2:
+        return 35.0, "Breakout above 20-day high with volume confirmation"
+
+    return None, ""
+
+
+def _pullback_signal(
+    closes: pd.Series, last_sma50: float, last_sma200: float, last_rsi: float
+) -> Tuple[float | None, str]:
+    if np.isnan(last_sma50) or last_sma50 <= 0:
+        return None, ""
+
+    last_close = closes.iloc[-1]
+    distance = abs(last_close - last_sma50) / last_sma50
+    if distance <= 0.02 and 40 <= last_rsi <= 55 and last_close > last_sma200:
+        return 20.0, "Pullback entry near SMA50 with balanced momentum"
+
+    return None, ""
+
+
+def _trend_bias(
+    last_close: float, last_sma50: float, last_sma200: float, last_rsi: float
+) -> Tuple[float, str]:
+    if np.isnan(last_sma50):
+        return 5.0, "Above long-term trend"
+
+    if last_close > last_sma50 and 45 <= last_rsi <= 65:
+        return 12.0, "Trending above SMA50 with supportive momentum"
+
+    if last_close > last_sma200:
+        return 6.0, "Above long-term trend"
+
+    return 0.0, "Neutral setup"
+
+
+def _score_linear(value: float | None, low: float, high: float, *, reverse: bool = False) -> float | None:
+    if value is None or not _is_finite(value):
+        return None
+
+    if high <= low:
+        return 50.0
+
+    if reverse:
+        if value <= low:
+            return 100.0
+        if value >= high:
+            return 0.0
+        ratio = 1 - (value - low) / (high - low)
+    else:
+        if value <= low:
+            return 0.0
+        if value >= high:
+            return 100.0
+        ratio = (value - low) / (high - low)
+
+    return float(np.clip(ratio * 100.0, 0.0, 100.0))
+
+
+def _score_band(
+    value: float | None, *, low: float, sweet_low: float, sweet_high: float, high: float
+) -> float | None:
+    if value is None or not _is_finite(value):
+        return None
+    if value < low or value > high:
+        return 0.0
+    if sweet_low <= value <= sweet_high:
+        return 100.0
+    if value < sweet_low:
+        ratio = (value - low) / (sweet_low - low) if sweet_low != low else 0.0
+        return float(np.clip(ratio * 100.0, 0.0, 100.0))
+    ratio = (high - value) / (high - sweet_high) if high != sweet_high else 0.0
+    return float(np.clip(ratio * 100.0, 0.0, 100.0))
+
+
+def _aggregate_scores(scores: Iterable[float | None]) -> float:
+    valid = [score for score in scores if score is not None and _is_finite(score)]
+    if not valid:
+        return 0.0
+    return float(np.clip(float(np.mean(valid)), 0.0, 100.0))
+
+
+def _is_finite(value: float | None) -> bool:
+    return value is not None and np.isfinite(value)
+
+
+def _column_case_insensitive(df: pd.DataFrame, candidates: set[str]) -> pd.Series | None:
+    lowercase_map: Dict[str, object] = {}
+    for column in df.columns:
+        if isinstance(column, tuple):
+            name = str(column[-1]).lower()
+        else:
+            name = str(column).lower()
+        lowercase_map[name] = column if not isinstance(column, tuple) else column
+
+    for candidate in candidates:
+        name = candidate.lower()
+        if name in lowercase_map:
+            column = lowercase_map[name]
+            return df[column]
+    return None

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -1,0 +1,72 @@
+import math
+
+import numpy as np
+
+from core.data.fundamentals import read_fundamentals
+
+
+def test_read_fundamentals_parses_and_normalises_values():
+    info = {
+        "roe": "15.5%",
+        "roa": "0.12",
+        "grossMargin": "58%",
+        "operatingMargin": None,
+        "ebitdaMargin": "nan",
+        "revenueGrowth": "12.5%",
+        "earningsGrowth": "-0.05",
+        "trailingPE": "18.3",
+        "forwardPE": "15.7",
+        "pb": "4.2",
+        "enterpriseToEbitda": "10.5",
+        "debtToEquity": "1.5",
+        "totalDebt": "1.2B",
+        "totalCash": "800M",
+        "currentRatio": "1.8",
+        "dividendYield": "2.4%",
+        "payoutRatio": "45%",
+        "beta": 1.1,
+        "marketCap": 1_500_000_000,
+        "averageVolume": "1.2M",
+    }
+
+    fundamentals = read_fundamentals(info)
+
+    assert math.isclose(fundamentals["roe"], 0.155, rel_tol=1e-6)
+    assert math.isclose(fundamentals["revenueGrowth"], 0.125, rel_tol=1e-6)
+    assert math.isclose(fundamentals["totalDebt"], 1.2e9, rel_tol=1e-6)
+    assert math.isclose(fundamentals["totalCash"], 8.0e8, rel_tol=1e-6)
+    assert math.isclose(fundamentals["dividendYield"], 0.024, rel_tol=1e-6)
+    assert math.isclose(fundamentals["payoutRatio"], 0.45, rel_tol=1e-6)
+    assert math.isclose(fundamentals["averageVolume"], 1.2e6, rel_tol=1e-6)
+    assert np.isnan(fundamentals["operatingMargin"])
+    assert np.isnan(fundamentals["ebitdaMargin"])
+ 
+
+def test_read_fundamentals_handles_missing_info():
+    fundamentals = read_fundamentals(None)
+
+    assert set(fundamentals.keys()) == {
+        "roe",
+        "roa",
+        "grossMargin",
+        "operatingMargin",
+        "ebitdaMargin",
+        "revenueGrowth",
+        "earningsGrowth",
+        "trailingPE",
+        "forwardPE",
+        "pb",
+        "enterpriseToEbitda",
+        "debtToEquity",
+        "totalDebt",
+        "totalCash",
+        "currentRatio",
+        "dividendYield",
+        "payoutRatio",
+        "beta",
+        "marketCap",
+        "averageVolume",
+    }
+
+    assert all(np.isnan(value) for value in fundamentals.values())
+

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,127 @@
+import numpy as np
+import pandas as pd
+
+from core.scoring import (
+    composite,
+    score_dividend,
+    score_finance,
+    score_growth,
+    score_quality,
+    score_value,
+    timing_modifier,
+    zscore_mad,
+)
+
+
+def _price_frame(close_values: np.ndarray, volume_values: np.ndarray | None = None) -> pd.DataFrame:
+    dates = pd.date_range(end=pd.Timestamp("2024-01-31"), periods=len(close_values), freq="B")
+    close = pd.Series(close_values, index=dates)
+    volume = (
+        pd.Series(volume_values, index=dates)
+        if volume_values is not None
+        else pd.Series(np.full(len(close_values), 1_000_000), index=dates)
+    )
+    return pd.DataFrame(
+        {
+            "Open": close,
+            "High": close * 1.01,
+            "Low": close * 0.99,
+            "Close": close,
+            "Adj Close": close,
+            "Volume": volume,
+        }
+    )
+
+
+def test_zscore_mad_returns_zero_for_constant_series():
+    series = pd.Series([5, 5, 5, 5, 5], dtype=float)
+    result = zscore_mad(series)
+    assert np.allclose(result, 0.0)
+
+
+def test_score_blocks_distinguish_good_and_poor_fundamentals():
+    good = {
+        "roe": 0.28,
+        "roa": 0.16,
+        "grossMargin": 0.58,
+        "operatingMargin": 0.24,
+        "ebitdaMargin": 0.4,
+        "revenueGrowth": 0.28,
+        "earningsGrowth": 0.32,
+        "trailingPE": 15.0,
+        "forwardPE": 14.0,
+        "pb": 2.0,
+        "enterpriseToEbitda": 8.0,
+        "debtToEquity": 0.4,
+        "currentRatio": 2.1,
+        "totalDebt": 5e9,
+        "totalCash": 6.5e9,
+        "dividendYield": 0.035,
+        "payoutRatio": 0.45,
+    }
+
+    poor = {
+        "roe": 0.03,
+        "roa": 0.01,
+        "grossMargin": 0.18,
+        "operatingMargin": 0.05,
+        "ebitdaMargin": 0.08,
+        "revenueGrowth": -0.05,
+        "earningsGrowth": -0.12,
+        "trailingPE": 55.0,
+        "forwardPE": 48.0,
+        "pb": 9.0,
+        "enterpriseToEbitda": 25.0,
+        "debtToEquity": 3.5,
+        "currentRatio": 0.9,
+        "totalDebt": 8e9,
+        "totalCash": 1.5e9,
+        "dividendYield": 0.002,
+        "payoutRatio": 0.95,
+    }
+
+    assert score_quality(good) > score_quality(poor)
+    assert score_growth(good) > score_growth(poor)
+    assert score_value(good) > score_value(poor)
+    assert score_finance(good) > score_finance(poor)
+    assert score_dividend(good) > score_dividend(poor)
+
+
+def test_composite_respects_weights():
+    weights = {"quality": 50, "growth": 30, "value": 20}
+    parts = {"quality": 80, "growth": 60, "value": 40}
+    result = composite(weights, parts)
+    expected = (80 * 50 + 60 * 30 + 40 * 20) / sum(weights.values())
+    assert np.isclose(result, expected)
+
+
+def test_timing_modifier_flags_price_below_sma200():
+    closes = np.linspace(100, 80, 240)
+    df = _price_frame(closes)
+    modifier, reason = timing_modifier(df)
+    assert modifier == -20.0
+    assert "SMA200" in reason
+
+
+def test_timing_modifier_detects_breakout_with_volume_confirmation():
+    closes = np.concatenate([
+        np.linspace(80, 100, 220),
+        np.linspace(101, 120, 40),
+    ])
+    volumes = np.concatenate([
+        np.full(219, 900_000),
+        np.full(40, 1_500_000),
+        np.array([3_000_000]),
+    ])
+    df = _price_frame(closes, volumes)
+    modifier, reason = timing_modifier(df)
+    assert modifier >= 30.0
+    assert "Breakout" in reason
+
+
+def test_timing_modifier_requires_history():
+    closes = np.linspace(90, 100, 40)
+    df = _price_frame(closes)
+    modifier, reason = timing_modifier(df)
+    assert modifier == 0.0
+    assert "history" in reason.lower()


### PR DESCRIPTION
## Summary
- add a fundamentals reader that normalises yfinance info payloads for scoring
- introduce core scoring helpers for quality/growth/value/finance/dividend blocks and timing modifier logic
- cover the new functionality with unit tests for fundamentals parsing and scoring heuristics

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest

------
https://chatgpt.com/codex/tasks/task_e_68d77bebb91c832f93c50a65e6733b02