### PR TITLE
Implement interactive Qt UI shell with streaming results

### DIFF
--- a/app/ui/components/__init__.py
+++ b/app/ui/components/__init__.py
@@ -1,0 +1,19 @@
+"""Convenience imports for UI components."""
+
+from .chart_widget import ChartWidget
+from .filters_panel import FiltersDock
+from .insight_panel import InsightPanel
+from .results_table import ResultRow, ResultsTableModel, ResultsTableView
+from .strategy_list import StrategyInfo, StrategyListWidget
+
+__all__ = [
+    "ChartWidget",
+    "FiltersDock",
+    "InsightPanel",
+    "ResultRow",
+    "ResultsTableModel",
+    "ResultsTableView",
+    "StrategyInfo",
+    "StrategyListWidget",
+]
+

--- a/app/ui/components/chart_widget.py
+++ b/app/ui/components/chart_widget.py
@@ -1,0 +1,57 @@
+"""Placeholder chart widget displaying contextual information."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from PyQt6 import QtCore, QtWidgets
+
+from core.models import TradeSignal
+
+__all__ = ["ChartWidget"]
+
+
+class ChartWidget(QtWidgets.QWidget):
+    """A lightweight placeholder until the full charting stack is implemented."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._title = QtWidgets.QLabel("Chart preview")
+        self._title.setObjectName("chartTitle")
+        self._title.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter)
+
+        self._summary = QtWidgets.QTextBrowser(self)
+        self._summary.setOpenExternalLinks(False)
+        self._summary.setReadOnly(True)
+        self._summary.setPlaceholderText("Select a result to preview price action and signals.")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._title)
+        layout.addWidget(self._summary)
+
+        self._symbol: str | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def set_symbol(self, symbol: str | None) -> None:
+        self._symbol = symbol
+        if symbol:
+            self._title.setText(f"{symbol} · Chart preview")
+        else:
+            self._title.setText("Chart preview")
+
+    def display_signals(self, signals: Iterable[TradeSignal]) -> None:
+        lines: List[str] = []
+        for signal in signals:
+            timestamp = signal.timestamp.strftime("%Y-%m-%d %H:%M")
+            lines.append(
+                f"<b>{signal.side.title()}</b> · {timestamp} · "
+                f"Confidence {signal.confidence:.0%} · {signal.reason}"
+            )
+        if not lines:
+            lines = ["No signals generated for the selected entry yet."]
+        content = "<br/>".join(lines)
+        self._summary.setHtml(content)
+

--- a/app/ui/components/filters_panel.py
+++ b/app/ui/components/filters_panel.py
@@ -1,0 +1,106 @@
+"""Dockable filters and parameter configuration panel."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from PyQt6 import QtCore, QtWidgets
+
+from core.config import DEFAULT_CONFIG
+
+__all__ = ["FiltersDock"]
+
+
+class FiltersDock(QtWidgets.QDockWidget):
+    """Provides parameter forms for the currently selected scan strategy."""
+
+    parametersChanged = QtCore.pyqtSignal(dict)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__("Filters", parent)
+        self.setObjectName("FiltersDock")
+        self.setAllowedAreas(
+            QtCore.Qt.DockWidgetArea.RightDockWidgetArea | QtCore.Qt.DockWidgetArea.LeftDockWidgetArea
+        )
+
+        self._stack = QtWidgets.QStackedWidget(self)
+        self.setWidget(self._stack)
+
+        self._forms: Dict[str, QtWidgets.QWidget] = {}
+        self._build_default_form()
+        self._build_lti_form()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def set_strategy(self, identifier: str) -> None:
+        widget = self._forms.get(identifier)
+        if widget is None:
+            widget = self._forms["default"]
+        self._stack.setCurrentWidget(widget)
+
+    def parameters(self) -> Dict[str, object]:
+        current = self._stack.currentWidget()
+        if current is None:
+            return {}
+        getter = getattr(current, "parameters", None)
+        if callable(getter):
+            return getter()
+        return {}
+
+    # ------------------------------------------------------------------
+    # Form builders
+    # ------------------------------------------------------------------
+    def _build_default_form(self) -> None:
+        widget = _FormContainer("No additional parameters for this strategy.")
+        self._forms["default"] = widget
+        self._stack.addWidget(widget)
+
+    def _build_lti_form(self) -> None:
+        widget = _LTICompounderForm(self)
+        self._forms["lti_compounder"] = widget
+        self._stack.addWidget(widget)
+
+
+class _FormContainer(QtWidgets.QWidget):
+    def __init__(self, message: str, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        label = QtWidgets.QLabel(message, self)
+        label.setWordWrap(True)
+        layout.addWidget(label)
+        layout.addStretch(1)
+
+    def parameters(self) -> Dict[str, object]:
+        return {}
+
+
+class _LTICompounderForm(QtWidgets.QWidget):
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QFormLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(8)
+
+        self._profile_combo = QtWidgets.QComboBox(self)
+        profiles = sorted(DEFAULT_CONFIG.profiles.lti_profiles.keys())
+        for profile in profiles:
+            self._profile_combo.addItem(profile.title(), profile)
+
+        self._threshold_spin = QtWidgets.QDoubleSpinBox(self)
+        self._threshold_spin.setRange(0.0, 100.0)
+        self._threshold_spin.setDecimals(1)
+        self._threshold_spin.setSingleStep(1.0)
+        self._threshold_spin.setValue(60.0)
+
+        layout.addRow("Profile", self._profile_combo)
+        layout.addRow("Score threshold", self._threshold_spin)
+        layout.addItem(QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding))
+
+    def parameters(self) -> Dict[str, object]:
+        return {
+            "profile": self._profile_combo.currentData(),
+            "threshold": float(self._threshold_spin.value()),
+        }
+

--- a/app/ui/components/insight_panel.py
+++ b/app/ui/components/insight_panel.py
@@ -1,0 +1,88 @@
+"""Insight panel showing metrics and narrative for the selected result."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from PyQt6 import QtCore, QtWidgets
+
+from core.models import ScanResult, TradeSignal
+
+__all__ = ["InsightPanel"]
+
+
+class InsightPanel(QtWidgets.QWidget):
+    """Contextual details about the selected scan result."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._title = QtWidgets.QLabel("Insights")
+        self._title.setObjectName("insightTitle")
+        self._title.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter)
+
+        self._badges = QtWidgets.QLabel()
+        self._badges.setWordWrap(True)
+
+        self._reasons = QtWidgets.QTextBrowser()
+        self._reasons.setReadOnly(True)
+        self._reasons.setPlaceholderText("Select a row to inspect the top reasons and signals.")
+
+        self._signals = QtWidgets.QTextBrowser()
+        self._signals.setReadOnly(True)
+        self._signals.setPlaceholderText("Trade signals emitted by the selected strategy will appear here.")
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+        layout.addWidget(self._title)
+        layout.addWidget(self._badges)
+
+        layout.addWidget(QtWidgets.QLabel("Top reasons"))
+        layout.addWidget(self._reasons, 1)
+        layout.addWidget(QtWidgets.QLabel("Signal history"))
+        layout.addWidget(self._signals, 1)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def show_result(self, result: ScanResult | None, signals: Iterable[TradeSignal]) -> None:
+        if result is None:
+            self._title.setText("Insights")
+            self._badges.setText("Select a result to view details.")
+            self._reasons.clear()
+            self._signals.clear()
+            return
+
+        self._title.setText(f"{result.symbol} · {result.score:.1f}")
+        self._badges.setText(self._format_badges(result))
+        self._reasons.setHtml("<br/>".join(result.reasons) or "No reasons available.")
+        self._signals.setHtml(self._format_signals(signals))
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _format_badges(result: ScanResult) -> str:
+        metrics = result.metrics or {}
+        tags = []
+        for key in ("score_quality", "score_growth", "score_value", "score_finance", "score_dividend"):
+            value = metrics.get(key)
+            if value is None:
+                continue
+            tags.append(f"<b>{key.split('_')[-1].title()}</b>: {value:.0f}")
+        if not tags:
+            return ""
+        return " · ".join(tags)
+
+    @staticmethod
+    def _format_signals(signals: Iterable[TradeSignal]) -> str:
+        lines = []
+        for signal in signals:
+            timestamp = signal.timestamp.strftime("%Y-%m-%d %H:%M")
+            lines.append(
+                f"<b>{signal.side.title()}</b> — {timestamp} — Confidence {signal.confidence:.0%}<br/>{signal.reason}"
+            )
+        if not lines:
+            return "No signals for this entry."
+        return "<hr/>".join(lines)
+

--- a/app/ui/components/results_table.py
+++ b/app/ui/components/results_table.py
@@ -1,0 +1,160 @@
+"""Streaming results table for displaying scan outputs."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from core.models import ScanResult, TradeSignal
+
+__all__ = ["ResultsTableModel", "ResultsTableView", "ResultRow"]
+
+
+@dataclass
+class ResultRow:
+    result: ScanResult
+    signals: List[TradeSignal]
+
+
+class ResultsTableModel(QtCore.QAbstractTableModel):
+    """Model storing :class:`ScanResult` entries as they stream in."""
+
+    HEADERS: Sequence[str] = (
+        "Symbol",
+        "Score",
+        "Last Price",
+        "Signals",
+        "Top Reasons",
+        "As of",
+    )
+
+    def __init__(self, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self._rows: List[ResultRow] = []
+        self._index: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Qt Model interface
+    # ------------------------------------------------------------------
+    def rowCount(self, parent: QtCore.QModelIndex | QtCore.QPersistentModelIndex = QtCore.QModelIndex()) -> int:  # type: ignore[override]
+        if parent.isValid():
+            return 0
+        return len(self._rows)
+
+    def columnCount(self, parent: QtCore.QModelIndex | QtCore.QPersistentModelIndex = QtCore.QModelIndex()) -> int:  # type: ignore[override]
+        if parent.isValid():
+            return 0
+        return len(self.HEADERS)
+
+    def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = QtCore.Qt.ItemDataRole.DisplayRole):  # type: ignore[override]
+        if role != QtCore.Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == QtCore.Qt.Orientation.Horizontal:
+            try:
+                return self.HEADERS[section]
+            except IndexError:
+                return None
+        return str(section + 1)
+
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.ItemDataRole.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+
+        row = index.row()
+        if row < 0 or row >= len(self._rows):
+            return None
+
+        result_row = self._rows[row]
+        result = result_row.result
+
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
+            column = index.column()
+            if column == 0:
+                return result.symbol
+            if column == 1:
+                return f"{result.score:.1f}"
+            if column == 2:
+                return f"{result.last_price:.2f}"
+            if column == 3:
+                counts = _signal_counts(result_row.signals)
+                return ", ".join(
+                    f"{side.title()}: {count}"
+                    for side, count in counts.items()
+                    if count > 0
+                ) or "—"
+            if column == 4:
+                return "; ".join(result.reasons)
+            if column == 5:
+                return result.as_of.strftime("%Y-%m-%d %H:%M")
+
+        if role == QtCore.Qt.ItemDataRole.ToolTipRole:
+            return "\n".join(result.reasons)
+
+        if role == QtCore.Qt.ItemDataRole.TextAlignmentRole:
+            if index.column() in {1, 2, 3}:
+                return int(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+
+        if role == QtCore.Qt.ItemDataRole.FontRole and index.column() == 0:
+            font = QtGui.QFont()
+            font.setBold(True)
+            return font
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Custom API
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        if not self._rows:
+            return
+        self.beginResetModel()
+        self._rows.clear()
+        self._index.clear()
+        self.endResetModel()
+
+    def upsert_row(self, result: ScanResult, signals: List[TradeSignal]) -> None:
+        """Insert or update the row matching *result.symbol*."""
+
+        row_index = self._index.get(result.symbol)
+        if row_index is None:
+            row_index = len(self._rows)
+            self.beginInsertRows(QtCore.QModelIndex(), row_index, row_index)
+            self._rows.append(ResultRow(result=result, signals=signals))
+            self._index[result.symbol] = row_index
+            self.endInsertRows()
+            return
+
+        self._rows[row_index] = ResultRow(result=result, signals=signals)
+        top_left = self.index(row_index, 0)
+        bottom_right = self.index(row_index, self.columnCount() - 1)
+        self.dataChanged.emit(top_left, bottom_right, [])
+
+    def row_at(self, row: int) -> ResultRow | None:
+        if 0 <= row < len(self._rows):
+            return self._rows[row]
+        return None
+
+
+class ResultsTableView(QtWidgets.QTableView):
+    """Configured table view for presenting scan results."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        self.setAlternatingRowColors(True)
+        self.setSortingEnabled(True)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.verticalHeader().setVisible(False)
+        self.setWordWrap(False)
+
+
+def _signal_counts(signals: Sequence[TradeSignal]) -> Dict[str, int]:
+    counts: Dict[str, int] = defaultdict(int)
+    for signal in signals:
+        counts[signal.side] += 1
+    return counts
+

--- a/app/ui/components/strategy_list.py
+++ b/app/ui/components/strategy_list.py
@@ -1,0 +1,119 @@
+"""Strategy browser widget used to explore available scan scenarios."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from PyQt6 import QtCore, QtWidgets
+
+from core.scans import SCENARIO_REGISTRY, BaseScenario
+
+__all__ = ["StrategyListWidget", "StrategyInfo"]
+
+
+@dataclass(frozen=True)
+class StrategyInfo:
+    """Presentation data describing a scan strategy."""
+
+    identifier: str
+    name: str
+    description: str
+
+
+class StrategyListWidget(QtWidgets.QWidget):
+    """Sidebar widget listing the registered scan strategies."""
+
+    strategySelected = QtCore.pyqtSignal(str)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._items: Dict[str, StrategyInfo] = self._load_strategies()
+
+        self._search = QtWidgets.QLineEdit(self)
+        self._search.setPlaceholderText("Search strategies…")
+        self._search.textChanged.connect(self._apply_filter)
+
+        self._list = QtWidgets.QListWidget(self)
+        self._list.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        self._list.itemSelectionChanged.connect(self._on_selection_changed)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._search)
+        layout.addWidget(self._list)
+
+        self._populate()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def select_strategy(self, identifier: str) -> None:
+        """Select the strategy matching *identifier* if present."""
+
+        for index in range(self._list.count()):
+            item = self._list.item(index)
+            if item.data(QtCore.Qt.ItemDataRole.UserRole) == identifier:
+                self._list.setCurrentRow(index)
+                self._ensure_visible(index)
+                return
+
+    def current_strategy(self) -> str | None:
+        item = self._list.currentItem()
+        if item is None:
+            return None
+        return item.data(QtCore.Qt.ItemDataRole.UserRole)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _populate(self) -> None:
+        self._list.clear()
+        for info in self._items.values():
+            item = QtWidgets.QListWidgetItem(info.name)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, info.identifier)
+            item.setToolTip(info.description)
+            item.setData(QtCore.Qt.ItemDataRole.StatusTipRole, info.description)
+            self._list.addItem(item)
+        if self._list.count() > 0:
+            self._list.setCurrentRow(0)
+
+    def _apply_filter(self, query: str) -> None:
+        query_normalised = query.strip().lower()
+        for index in range(self._list.count()):
+            item = self._list.item(index)
+            info = self._items[item.data(QtCore.Qt.ItemDataRole.UserRole)]
+            visible = True
+            if query_normalised:
+                haystack = f"{info.name} {info.description}".lower()
+                visible = query_normalised in haystack
+            item.setHidden(not visible)
+
+    def _on_selection_changed(self) -> None:
+        identifier = self.current_strategy()
+        if identifier is not None:
+            self.strategySelected.emit(identifier)
+
+    def _ensure_visible(self, index: int) -> None:
+        item = self._list.item(index)
+        if item is not None:
+            self._list.scrollToItem(item)
+
+    @staticmethod
+    def _load_strategies() -> Dict[str, StrategyInfo]:
+        strategies: List[Tuple[str, StrategyInfo]] = []
+        for identifier, scenario_cls in SCENARIO_REGISTRY.items():
+            scenario: BaseScenario = scenario_cls()
+            strategies.append(
+                (
+                    identifier,
+                    StrategyInfo(
+                        identifier=identifier,
+                        name=getattr(scenario, "name", identifier.title()),
+                        description=getattr(scenario, "description", ""),
+                    ),
+                )
+            )
+        strategies.sort(key=lambda item: item[1].name.lower())
+        return dict(strategies)
+

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1,24 +1,342 @@
-"""Initial placeholder implementation of the main application window."""
+"""Main window implementation for the Rectifex Global Screener UI."""
 
 from __future__ import annotations
 
-from PyQt6 import QtCore, QtWidgets
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from core.models import ScanResult, TradeSignal
+from core.runners import ScanRunner, ScanSummary
+from core.scans import SCENARIO_REGISTRY, BaseScenario
+
+from .components import (
+    ChartWidget,
+    FiltersDock,
+    InsightPanel,
+    ResultsTableModel,
+    ResultsTableView,
+    StrategyListWidget,
+)
+
+__all__ = ["MainWindow"]
+
+
+class _ScanBridge(QtCore.QObject):
+    resultReceived = QtCore.pyqtSignal(object, object)  # ScanResult | None, List[TradeSignal]
+    progressUpdated = QtCore.pyqtSignal(object)  # ScanProgress
+    scanFinished = QtCore.pyqtSignal(object, object)  # ScanSummary | None, Exception | None
 
 
 class MainWindow(QtWidgets.QMainWindow):
-    """Skeleton main window used during early development stages."""
+    """Interactive desktop front-end coordinating scans and UI updates."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, runner: Optional[ScanRunner] = None, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
         self.setWindowTitle("Rectifex Global Screener")
-        self.resize(1024, 768)
+        self.resize(1280, 840)
 
-        label = QtWidgets.QLabel(
-            "Rectifex Global Screener\nUI implementation is in progress.", self
-        )
-        label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self._runner = runner or ScanRunner(max_workers=4)
+        self._owns_runner = runner is None
+        self._bridge = _ScanBridge(self)
+        self._signal_store: Dict[str, List[TradeSignal]] = {}
 
+        self._bridge.resultReceived.connect(self._handle_stream_result)
+        self._bridge.progressUpdated.connect(self._update_progress)
+        self._bridge.scanFinished.connect(self._scan_finished)
+
+        self._results_model = ResultsTableModel(self)
+        self._results_view = ResultsTableView(self)
+        self._results_view.setModel(self._results_model)
+        header = self._results_view.horizontalHeader()
+        header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Interactive)
+        header.setStretchLastSection(True)
+
+        self._chart_widget = ChartWidget(self)
+        self._insight_panel = InsightPanel(self)
+
+        self._strategy_sidebar = StrategyListWidget(self)
+        self._strategy_sidebar.strategySelected.connect(self._on_sidebar_strategy)
+
+        self._filters_dock = FiltersDock(self)
+        self.addDockWidget(QtCore.Qt.DockWidgetArea.RightDockWidgetArea, self._filters_dock)
+
+        self._progress_label = QtWidgets.QLabel("Idle")
+        self._cache_label = QtWidgets.QLabel("Cache: n/a")
+        status_bar = self.statusBar()
+        status_bar.addPermanentWidget(self._progress_label)
+        status_bar.addPermanentWidget(self._cache_label)
+
+        self._setup_toolbar()
+        self.setCentralWidget(self._build_layout())
+
+        selection_model = self._results_view.selectionModel()
+        if selection_model is not None:
+            selection_model.currentChanged.connect(self._on_selection_changed)
+
+        self._populate_strategy_controls()
+        self._set_controls_enabled(True)
+
+    # ------------------------------------------------------------------
+    # UI construction helpers
+    # ------------------------------------------------------------------
+    def _setup_toolbar(self) -> None:
+        toolbar = QtWidgets.QToolBar("Controls", self)
+        toolbar.setMovable(False)
+        toolbar.setIconSize(QtCore.QSize(16, 16))
+        self.addToolBar(QtCore.Qt.ToolBarArea.TopToolBarArea, toolbar)
+
+        self._strategy_combo = QtWidgets.QComboBox(self)
+        self._strategy_combo.currentIndexChanged.connect(self._on_strategy_combo_changed)
+
+        self._period_combo = QtWidgets.QComboBox(self)
+        for label, value in self._period_options():
+            self._period_combo.addItem(label, value)
+        self._period_combo.setCurrentIndex(1)
+
+        self._tickers_edit = QtWidgets.QLineEdit(self)
+        self._tickers_edit.setPlaceholderText("Enter comma separated tickers e.g. AAPL, MSFT, GOOGL")
+        self._tickers_edit.returnPressed.connect(self._start_scan)
+
+        self._run_button = QtWidgets.QPushButton("Run", self)
+        self._run_button.setShortcut(QtGui.QKeySequence("Ctrl+R"))
+        self._run_button.clicked.connect(self._start_scan)
+
+        self._stop_button = QtWidgets.QPushButton("Stop", self)
+        self._stop_button.setShortcut(QtGui.QKeySequence("Escape"))
+        self._stop_button.clicked.connect(self._stop_scan)
+        self._stop_button.setEnabled(False)
+
+        toolbar.addWidget(QtWidgets.QLabel("Strategy", self))
+        toolbar.addWidget(self._strategy_combo)
+        toolbar.addSeparator()
+        toolbar.addWidget(QtWidgets.QLabel("Period", self))
+        toolbar.addWidget(self._period_combo)
+        toolbar.addSeparator()
+        toolbar.addWidget(QtWidgets.QLabel("Universe", self))
+        toolbar.addWidget(self._tickers_edit)
+        toolbar.addSeparator()
+        toolbar.addWidget(self._run_button)
+        toolbar.addWidget(self._stop_button)
+
+    def _build_layout(self) -> QtWidgets.QWidget:
         central = QtWidgets.QWidget(self)
         layout = QtWidgets.QVBoxLayout(central)
-        layout.addWidget(label)
-        self.setCentralWidget(central)
+        layout.setContentsMargins(6, 6, 6, 6)
+        layout.setSpacing(6)
+
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal, central)
+        splitter.addWidget(self._strategy_sidebar)
+
+        results_container = QtWidgets.QWidget(splitter)
+        results_layout = QtWidgets.QVBoxLayout(results_container)
+        results_layout.setContentsMargins(0, 0, 0, 0)
+        results_layout.addWidget(self._results_view)
+        splitter.addWidget(results_container)
+
+        right_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical, splitter)
+        right_splitter.addWidget(self._insight_panel)
+        right_splitter.addWidget(self._chart_widget)
+        splitter.addWidget(right_splitter)
+
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setStretchFactor(2, 0)
+        layout.addWidget(splitter)
+
+        return central
+
+    def _populate_strategy_controls(self) -> None:
+        self._strategy_combo.blockSignals(True)
+        self._strategy_combo.clear()
+        entries: List[Tuple[str, BaseScenario]] = []
+        for identifier, scenario_cls in SCENARIO_REGISTRY.items():
+            scenario = scenario_cls()
+            entries.append((identifier, scenario))
+        entries.sort(key=lambda pair: pair[1].name.lower())
+
+        for identifier, scenario in entries:
+            self._strategy_combo.addItem(scenario.name, identifier)
+
+        self._strategy_combo.blockSignals(False)
+        if self._strategy_combo.count() > 0:
+            self._strategy_combo.setCurrentIndex(0)
+            self._strategy_sidebar.select_strategy(self._current_strategy())
+            self._filters_dock.set_strategy(self._current_strategy())
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+    def _on_strategy_combo_changed(self, index: int) -> None:
+        identifier = self._current_strategy()
+        if identifier is None:
+            return
+        self._strategy_sidebar.select_strategy(identifier)
+        self._filters_dock.set_strategy(identifier)
+
+    def _on_sidebar_strategy(self, identifier: str) -> None:
+        combo_index = self._strategy_combo.findData(identifier)
+        if combo_index >= 0:
+            self._strategy_combo.setCurrentIndex(combo_index)
+
+    def _on_selection_changed(
+        self, current: QtCore.QModelIndex, previous: QtCore.QModelIndex
+    ) -> None:  # pragma: no cover - trivial glue
+        self._update_insight_from_index(current)
+
+    def _start_scan(self) -> None:
+        strategy_id = self._current_strategy()
+        if strategy_id is None:
+            QtWidgets.QMessageBox.warning(self, "Strategy", "Please select a strategy to run.")
+            return
+
+        tickers = self._parse_tickers(self._tickers_edit.text())
+        if not tickers:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Tickers required",
+                "Provide at least one ticker (comma separated) before starting a scan.",
+            )
+            return
+
+        params = self._filters_dock.parameters()
+        period = self._period_combo.currentData()
+
+        self._signal_store.clear()
+        self._results_model.clear()
+        self._progress_label.setText("Starting…")
+        self._cache_label.setText("Cache: pending")
+        self._set_controls_enabled(False)
+        self._stop_button.setEnabled(True)
+
+        scenario = SCENARIO_REGISTRY[strategy_id]()
+
+        def _on_result(result: Optional[ScanResult], signals: List[TradeSignal]) -> None:
+            self._bridge.resultReceived.emit(result, signals)
+
+        def _on_progress(progress) -> None:
+            self._bridge.progressUpdated.emit(progress)
+
+        future = self._runner.start(
+            scenario,
+            tickers,
+            params=params,
+            period=str(period),
+            on_result=_on_result,
+            on_progress=_on_progress,
+        )
+
+        def _on_done(fut) -> None:
+            summary: Optional[ScanSummary] = None
+            error: Optional[Exception] = None
+            try:
+                summary = fut.result()
+            except Exception as exc:  # pragma: no cover - defensive
+                error = exc
+            self._bridge.scanFinished.emit(summary, error)
+
+        future.add_done_callback(_on_done)
+
+    def _stop_scan(self) -> None:
+        self._runner.stop()
+        self._stop_button.setEnabled(False)
+        self._progress_label.setText("Stopping…")
+
+    def _handle_stream_result(self, result: Optional[ScanResult], signals: List[TradeSignal]) -> None:
+        if result is not None:
+            self._signal_store[result.symbol] = list(signals)
+            self._results_model.upsert_row(result, list(signals))
+            if self._results_model.rowCount() == 1:
+                index = self._results_model.index(0, 0)
+                self._results_view.selectRow(0)
+                self._update_insight_from_index(index)
+        elif signals:
+            # Assign signals to their symbol when result omitted (e.g. watch alerts)
+            for signal in signals:
+                bucket = self._signal_store.setdefault(signal.symbol, [])
+                bucket.append(signal)
+        self._update_selected_signals()
+
+    def _update_progress(self, progress) -> None:
+        self._progress_label.setText(
+            f"Processed {progress.processed}/{progress.total} · Skipped {progress.skipped} · Errors {progress.errors}"
+        )
+
+    def _scan_finished(self, summary: Optional[ScanSummary], error: Optional[Exception]) -> None:
+        self._set_controls_enabled(True)
+        self._stop_button.setEnabled(False)
+        if error is not None:
+            self._progress_label.setText("Scan failed")
+            QtWidgets.QMessageBox.critical(self, "Scan failed", str(error))
+            return
+        if summary is None:
+            self._progress_label.setText("Scan cancelled")
+            return
+        self._progress_label.setText(
+            f"Completed in {summary.duration_seconds:.1f}s · Processed {summary.processed}/{summary.total}"
+        )
+        self._cache_label.setText(
+            f"Cache hits {summary.cache_hits} · misses {summary.cache_misses}"
+        )
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _current_strategy(self) -> Optional[str]:
+        return self._strategy_combo.currentData()
+
+    @staticmethod
+    def _parse_tickers(text: str) -> List[str]:
+        entries = [entry.strip().upper() for entry in text.replace("\n", ",").split(",")]
+        return [entry for entry in entries if entry]
+
+    def _update_insight_from_index(self, index: QtCore.QModelIndex) -> None:
+        if not index.isValid():
+            self._insight_panel.show_result(None, [])
+            self._chart_widget.set_symbol(None)
+            self._chart_widget.display_signals([])
+            return
+
+        row = index.row()
+        row_data = self._results_model.row_at(row)
+        if row_data is None:
+            self._insight_panel.show_result(None, [])
+            return
+
+        signals = self._signal_store.get(row_data.result.symbol, row_data.signals)
+        self._insight_panel.show_result(row_data.result, signals)
+        self._chart_widget.set_symbol(row_data.result.symbol)
+        self._chart_widget.display_signals(signals)
+
+    def _update_selected_signals(self) -> None:
+        index = self._results_view.currentIndex()
+        if index.isValid():
+            self._update_insight_from_index(index)
+
+    def _set_controls_enabled(self, enabled: bool) -> None:
+        self._run_button.setEnabled(enabled)
+        self._strategy_combo.setEnabled(enabled)
+        self._period_combo.setEnabled(enabled)
+        self._tickers_edit.setEnabled(enabled)
+
+    @staticmethod
+    def _period_options() -> Sequence[Tuple[str, str]]:
+        return (
+            ("3 Months", "3mo"),
+            ("6 Months", "6mo"),
+            ("1 Year", "1y"),
+            ("2 Years", "2y"),
+            ("5 Years", "5y"),
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # pragma: no cover - Qt callback
+        try:
+            self._runner.stop()
+            if self._owns_runner:
+                self._runner.shutdown()
+        finally:
+            super().closeEvent(event)
+

--- a/core/scans/floor_consolidation.py
+++ b/core/scans/floor_consolidation.py
@@ -19,8 +19,8 @@ __all__ = [
 
 class _BaseFloorScenario(BaseScenario):
     range_window: int = 30
-    breakout_buffer: float = 0.01
-    max_range_pct: float = 0.08
+    breakout_buffer: float = 0.005
+    max_range_pct: float = 0.12
     volume_multiplier: float = 1.25
 
     def _evaluate_common(self, context: object) -> Optional[dict]:
@@ -48,7 +48,8 @@ class _BaseFloorScenario(BaseScenario):
         volume_ma_series = vol_ma(volume, 20)
         last_volume = float(volume.iloc[-1])
         last_volume_ma = float(volume_ma_series.iloc[-1])
-        breakout = last_close >= last_high * (1 + self.breakout_buffer)
+        breakout_trigger = last_high * (1 - self.breakout_buffer)
+        breakout = last_close >= breakout_trigger
         volume_confirm = last_volume_ma > 0 and last_volume >= last_volume_ma * self.volume_multiplier
         rsi_series = rsi(closes, 14)
         last_rsi = float(rsi_series.iloc[-1])

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from concurrent.futures import Future
+from datetime import datetime
+
+import pandas as pd
+import pytest
+from PyQt6 import QtCore
+
+from app.ui.main_window import MainWindow
+from core.models import ScanResult, TradeSignal
+from core.runners import ScanProgress, ScanSummary
+
+
+class DummyRunner:
+    def __init__(self) -> None:
+        # Bypass parent initialisation to avoid threads
+        self.started = False
+        self.stopped = False
+        self.shutdown_called = False
+        self._tickers: list[str] = []
+
+    def start(
+        self,
+        strategy,
+        symbols,
+        *,
+        params=None,
+        period="1y",
+        on_result=None,
+        on_progress=None,
+    ):
+        self.started = True
+        self._tickers = list(symbols)
+
+        future: Future[ScanSummary] = Future()
+
+        def _emit() -> None:
+            progress = ScanProgress(total=len(self._tickers), processed=1, skipped=0, errors=0)
+            if on_progress is not None:
+                on_progress(progress)
+
+            if on_result is not None:
+                result = ScanResult(
+                    symbol=self._tickers[0],
+                    score=72.5,
+                    metrics={"final_score": 72.5},
+                    reasons=["Momentum breakout"],
+                    last_price=123.45,
+                    as_of=datetime.utcnow(),
+                )
+                signal = TradeSignal(
+                    symbol=self._tickers[0],
+                    timestamp=pd.Timestamp.utcnow(),
+                    side="buy",
+                    confidence=0.85,
+                    reason="Dummy trigger",
+                    scenario_id="dummy",
+                )
+                on_result(result, [signal])
+
+            future.set_result(
+                ScanSummary(
+                    total=len(self._tickers),
+                    processed=len(self._tickers),
+                    skipped=0,
+                    errors=0,
+                    cache_hits=0,
+                    cache_misses=len(self._tickers),
+                    duration_seconds=0.1,
+                )
+            )
+
+        QtCore.QTimer.singleShot(0, _emit)
+        return future
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_main_window_streams_results(qtbot) -> None:
+    runner = DummyRunner()
+    window = MainWindow(runner=runner)
+    qtbot.addWidget(window)
+    window.show()
+    qtbot.waitExposed(window)
+
+    window._tickers_edit.setText("AAA, BBB")
+    qtbot.mouseClick(window._run_button, QtCore.Qt.MouseButton.LeftButton)
+
+    qtbot.waitUntil(lambda: window._results_model.rowCount() > 0, timeout=2000)
+    assert window._results_model.rowCount() == 1
+    row = window._results_model.row_at(0)
+    assert row is not None
+    assert row.result.symbol == "AAA"
+
+    qtbot.waitUntil(lambda: "Completed" in window._progress_label.text(), timeout=2000)
+    assert "Cache hits" in window._cache_label.text()
+
+    window.close()
+    assert runner.shutdown_called is False  # Runner owned externally
+


### PR DESCRIPTION
## Summary
- Replace the placeholder main window with a modular PyQt6 layout that wires ScanRunner streaming callbacks into a toolbar-controlled workflow, strategy browser, results table, insight panel, and chart preview.
- Introduce reusable UI components for strategy selection, virtualized results rendering, parameter filters, insights, and signal summaries to keep the window lean and composable.
- Refine contrarian and floor consolidation scans to honour recent oversold rebounds and tolerant breakout triggers, and add a pytest-qt smoke test covering the new UI flow.

## Testing
- QT_QPA_PLATFORM=offscreen pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d786cc4718832f8ce289db9f6a9e72