### PR TITLE
Improve yfinance fundamentals extraction

### DIFF
--- a/core/data/fundamentals.py
+++ b/core/data/fundamentals.py
@@ -1,10 +1,11 @@
-"""Utilities to normalise fundamental data returned by yfinance."""
+"""Utilities for defensively extracting fundamental metrics from yfinance."""
 
 from __future__ import annotations
 
-from typing import Dict, Mapping
+from typing import Dict, Mapping, Sequence
 
 import numpy as np
+import pandas as pd
 
 __all__ = ["read_fundamentals"]
 
@@ -32,6 +33,29 @@ _FUNDAMENTAL_KEYS = [
     "averageVolume",
 ]
 
+_ALIAS_PATHS: Dict[str, Sequence[Sequence[str] | str]] = {
+    "roe": ["returnOnEquity", ("financialData", "returnOnEquity")],
+    "roa": ["returnOnAssets", ("financialData", "returnOnAssets")],
+    "grossMargin": ["grossMargins", ("financialData", "grossMargins")],
+    "operatingMargin": ["operatingMargins", ("financialData", "operatingMargins")],
+    "ebitdaMargin": ["ebitdaMargins", ("financialData", "ebitdaMargins")],
+    "revenueGrowth": [("financialData", "revenueGrowth")],
+    "earningsGrowth": [("financialData", "earningsGrowth")],
+    "trailingPE": [("summaryDetail", "trailingPE")],
+    "forwardPE": [("summaryDetail", "forwardPE")],
+    "pb": ["priceToBook", ("summaryDetail", "priceToBook")],
+    "enterpriseToEbitda": [("summaryDetail", "enterpriseToEbitda")],
+    "debtToEquity": [("financialData", "debtToEquity")],
+    "totalDebt": [("balanceSheet", "Total Debt"), ("financialData", "totalDebt")],
+    "totalCash": [("balanceSheet", "Cash And Cash Equivalents"), ("financialData", "totalCash")],
+    "currentRatio": [("financialData", "currentRatio")],
+    "dividendYield": [("summaryDetail", "dividendYield")],
+    "payoutRatio": [("summaryDetail", "payoutRatio")],
+    "beta": [("summaryDetail", "beta")],
+    "marketCap": [("summaryDetail", "marketCap"), ("price", "marketCap")],
+    "averageVolume": [("summaryDetail", "averageVolume"), ("price", "averageDailyVolume10Day")],
+}
+
 
 def read_fundamentals(info: Mapping[str, object] | None) -> Dict[str, float]:
     """Return a normalised dictionary of fundamental metrics.
@@ -41,14 +65,69 @@ def read_fundamentals(info: Mapping[str, object] | None) -> Dict[str, float]:
     is extracted to keep the downstream scoring logic deterministic.
     """
 
-    if info is None:
+    normalised = _normalise_mapping(info)
+    if normalised is None:
         return {key: np.nan for key in _FUNDAMENTAL_KEYS}
 
     result: Dict[str, float] = {}
     for key in _FUNDAMENTAL_KEYS:
-        raw_value = info.get(key) if isinstance(info, Mapping) else None
+        raw_value = _extract_value(normalised, key)
         result[key] = _coerce_numeric(raw_value)
     return result
+
+
+def _normalise_mapping(info: object) -> Mapping[str, object] | None:
+    if info is None:
+        return None
+    if isinstance(info, Mapping):
+        return info
+    if hasattr(info, "to_dict"):
+        converted = info.to_dict()  # type: ignore[attr-defined]
+        if isinstance(converted, Mapping):
+            return converted
+    return None
+
+
+def _extract_value(info: Mapping[str, object], key: str) -> object:
+    if key in info:
+        return info[key]
+
+    for alias in _ALIAS_PATHS.get(key, ()):  # type: ignore[arg-type]
+        value = _value_from_alias(info, alias)
+        if value is not None:
+            return value
+    return None
+
+
+def _value_from_alias(info: Mapping[str, object], alias: Sequence[str] | str) -> object:
+    if isinstance(alias, str):
+        return info.get(alias)
+
+    current: object = info
+    for segment in alias:
+        if isinstance(current, Mapping):
+            current = current.get(segment)
+        elif isinstance(current, pd.DataFrame):
+            if segment in current.index:
+                series = current.loc[segment]
+                current = _first_scalar(series)
+            else:
+                return None
+        elif isinstance(current, pd.Series):
+            if segment in current.index:
+                current = _coerce_series_value(current[segment])
+            else:
+                return None
+        else:
+            return None
+
+        if current is None:
+            return None
+
+    if isinstance(current, Mapping):
+        if len(current) == 1:
+            return next(iter(current.values()))
+    return current
 
 
 def _coerce_numeric(value: object) -> float:
@@ -71,10 +150,17 @@ def _coerce_numeric(value: object) -> float:
             return float("nan")
         return float(value)
 
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, (list, tuple, set)):
         if not value:
             return float("nan")
-        return _coerce_numeric(value[0])
+        first = next(iter(value))
+        return _coerce_numeric(first)
+
+    if isinstance(value, pd.Series):
+        return _coerce_numeric(_first_scalar(value))
+
+    if isinstance(value, pd.DataFrame):
+        return _coerce_numeric(_first_scalar(value.stack(dropna=False)))
 
     if isinstance(value, str):
         text = value.strip()
@@ -110,6 +196,21 @@ def _coerce_numeric(value: object) -> float:
         return float(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return float("nan")
+
+
+def _first_scalar(series: pd.Series) -> object:
+    if series.empty:
+        return float("nan")
+    cleaned = series.dropna()
+    if not cleaned.empty:
+        return cleaned.iloc[0]
+    return series.iloc[0]
+
+
+def _coerce_series_value(value: object) -> object:
+    if isinstance(value, pd.Series):
+        return _first_scalar(value)
+    return value
 
 
 def _clean_numeric_string(text: str) -> str | None:


### PR DESCRIPTION
## Summary
- enhance `read_fundamentals` to pull metrics from nested yfinance payloads such as financialData and balanceSheet
- add robust coercion helpers for pandas Series/DataFrame and collection inputs to normalise values

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fundamentals.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d799f31ac4832fb5374266116d849c