### PR TITLE
Add cached universe loading and auto-scan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ and exports findings for further analysis.
 - **Resilient market data pipeline** that caches price history to Parquet,
   indexes metadata in SQLite, retries yfinance downloads with exponential
   backoff, and transparently falls back to stale cache entries when necessary.
+- **Universe loader & cache** that pulls NASDAQ/NYSE/S&P500 lists on demand,
+  stores them as CSV under `~/.cache/com.rectifex.GlobalScreener/universe`, and
+  automatically runs scans against `us-all` when no manual tickers are
+  provided.
 - **Streaming UI** backed by a thread-pooled `ScanRunner`. Results arrive in a
   virtualized table while insights, signal history, and chart overlays update
   instantly without blocking the main event loop.
@@ -66,17 +70,22 @@ rectifex-global-screener/
 
 4. **Execute the CLI**
 
-   Prepare a `tickers.txt` file (one symbol per line) and run:
+   You can provide a ticker file or let the CLI load a universe automatically:
 
    ```bash
    python -m cli.rectifex_cli scan \
      --strategy lti_compounder \
      --profile balanced \
-     --tickers tickers.txt \
+     --universe us-all \
+     --max-tickers 250 \
+     --refresh-days 7 \
      --period 5y \
      --out results.json \
      --include-signals
    ```
+
+   When `--tickers` is omitted the selected universe (default `us-all`) is
+   cached locally and reused until the refresh window expires.
 
 5. **Run tests and linters**
 
@@ -105,6 +114,17 @@ flatpak run --command=rectifex-cli com.rectifex.GlobalScreener --help  # Invoke 
 - When a ticker lacks fundamentals or price history, the scan logs the issue,
   marks the symbol as skipped, and continues processing the rest of the
   universe.
+
+## Ticker Universes & Custom Lists
+
+- Leaving the ticker field empty in the UI automatically loads the selected
+  universe (default: `us-all`) and displays a status hint before the scan
+  starts.
+- The toolbar exposes dropdowns for the universe, a maximum ticker cap, and the
+  refresh interval in days. The same options are available via CLI flags.
+- Cached universes are written to
+  `~/.cache/com.rectifex.GlobalScreener/universe/<name>.csv`. Populate
+  `custom.csv` in that directory to maintain your own set of symbols.
 
 ## Disclaimer
 

--- a/core/cache.py
+++ b/core/cache.py
@@ -17,5 +17,7 @@ class Cache:
         self.base_dir = _cache_root()
         self.prices_dir = self.base_dir / "prices"
         self.images_dir = self.base_dir / "images"
+        self.universe_dir = self.base_dir / "universe"
         self.prices_dir.mkdir(parents=True, exist_ok=True)
         self.images_dir.mkdir(parents=True, exist_ok=True)
+        self.universe_dir.mkdir(parents=True, exist_ok=True)

--- a/core/universe.py
+++ b/core/universe.py
@@ -1,0 +1,130 @@
+"""Utilities for loading and caching equity universes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import gzip
+import io
+from pathlib import Path
+import time
+
+import pandas as pd
+import requests
+
+
+DEFAULT_UNIVERSE = "us-all"
+DEFAULT_REFRESH_SECS = 7 * 24 * 3600
+
+
+@dataclass(frozen=True)
+class UniverseSpec:
+    """Describe which universe to load and how to cache it."""
+
+    name: str = DEFAULT_UNIVERSE
+    max_count: int | None = None
+    refresh_secs: int = DEFAULT_REFRESH_SECS
+
+
+class UniverseLoader:
+    """Load ticker universes from free public sources with caching."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def load(self, spec: UniverseSpec) -> pd.Series:
+        cache_file = self.cache_dir / f"{spec.name}.csv"
+        if cache_file.exists():
+            age = time.time() - cache_file.stat().st_mtime
+            if age < spec.refresh_secs:
+                series = pd.read_csv(cache_file)["symbol"]
+                return series.iloc[: spec.max_count] if spec.max_count else series
+
+        if spec.name == "us-all":
+            series = self._load_us_all()
+        elif spec.name == "sp500":
+            series = self._load_sp500()
+        elif spec.name == "nasdaq":
+            series = self._load_nasdaq_only()
+        elif spec.name == "nyse":
+            series = self._load_nyse_only()
+        elif spec.name == "custom":
+            series = self._load_custom(cache_file)
+        else:  # pragma: no cover - guarded by CLI/UI options
+            raise ValueError(f"Unknown universe: {spec.name}")
+
+        processed = self._postprocess_symbols(series)
+        processed.iloc[: spec.max_count].to_frame("symbol").to_csv(cache_file, index=False)
+        return processed.iloc[: spec.max_count] if spec.max_count else processed
+
+    # ------------------------------------------------------------------
+    # Universe sources
+    # ------------------------------------------------------------------
+    def _load_us_all(self) -> pd.Series:
+        nasdaq = self._download_csv_like(
+            "https://ftp.nasdaqtrader.com/dynamic/SymDir/nasdaqtraded.txt",
+            sep="|",
+        )
+        other = self._download_csv_like(
+            "https://ftp.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt",
+            sep="|",
+        )
+
+        nasdaq.columns = [col.lower() for col in nasdaq.columns]
+        other.columns = [col.lower() for col in other.columns]
+
+        sym1 = nasdaq.get("symbol") or nasdaq.get("nasdaq symbol")
+        sym2 = other.get("symbol") or other.get("act symbol")
+
+        combined = pd.concat([sym1, sym2], ignore_index=True).dropna().astype(str).str.upper()
+        return combined.drop_duplicates()
+
+    def _load_nasdaq_only(self) -> pd.Series:
+        df = self._download_csv_like(
+            "https://ftp.nasdaqtrader.com/dynamic/SymDir/nasdaqtraded.txt",
+            sep="|",
+        )
+        df.columns = [col.lower() for col in df.columns]
+        sym = df.get("symbol") or df.get("nasdaq symbol")
+        return sym.dropna().astype(str).str.upper().drop_duplicates()
+
+    def _load_nyse_only(self) -> pd.Series:
+        df = self._download_csv_like(
+            "https://ftp.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt",
+            sep="|",
+        )
+        df.columns = [col.lower() for col in df.columns]
+        sym = df.get("symbol") or df.get("act symbol")
+        return sym.dropna().astype(str).str.upper().drop_duplicates()
+
+    def _load_sp500(self) -> pd.Series:
+        tables = pd.read_html("https://en.wikipedia.org/wiki/List_of_S%26P_500_companies")
+        frame = tables[0]
+        column = "Symbol" if "Symbol" in frame.columns else "Ticker symbol"
+        return frame[column].astype(str).str.upper().drop_duplicates()
+
+    def _load_custom(self, path: Path) -> pd.Series:
+        if path.exists():
+            return pd.read_csv(path)["symbol"].astype(str).str.upper().drop_duplicates()
+        return pd.Series(dtype=str)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _download_csv_like(self, url: str, sep: str = ",") -> pd.DataFrame:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        content = response.content
+        if url.endswith(".gz") or content[:2] == b"\x1f\x8b":
+            content = gzip.decompress(content)
+        buffer = io.StringIO(content.decode("utf-8", errors="replace"))
+        return pd.read_csv(buffer, sep=sep)
+
+    def _postprocess_symbols(self, series: pd.Series) -> pd.Series:
+        cleaned = series[~series.str.contains(r"[\^=]", regex=True)]
+        cleaned = cleaned[~cleaned.str.contains(r"\$", regex=True)]
+        cleaned = cleaned[~cleaned.str.contains(r"\.", regex=True)]
+        cleaned = cleaned.str.replace(".", "-", regex=False)
+        cleaned = cleaned.drop_duplicates().sort_values(kind="stable").reset_index(drop=True)
+        return cleaned
+


### PR DESCRIPTION
## Summary
- add a reusable universe loader that downloads public symbol lists and caches them under the application cache directory
- allow the scan runner, CLI, and UI to fall back to cached universes when no manual ticker list is supplied and expose refresh/max options
- document the new behaviour and controls in the README so users know where universes live and how to configure them

## Testing
- ⚠️ `pytest -q` *(fails in CI container: missing libGL.so.1 needed by pytest-qt)*


------
https://chatgpt.com/codex/tasks/task_e_68d8227c9c90832f90a899fc4bb46896