### PR TITLE
docs: Update README and add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Rectifex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -96,13 +96,34 @@ rectifex-global-screener/
 
 ## Flatpak Packaging
 
-The Flatpak manifest installs pinned dependencies, copies the project into the
-application prefix, and exposes launch scripts for both the UI and CLI.
+The Flatpak manifest installs pinned dependencies from `requirements.txt`, copies the application source code into the sandbox, and exposes launch scripts for both the UI and CLI.
+
+### Prerequisites
+
+Before building, ensure you have `flatpak` and `flatpak-builder` installed on your system. You also need to add the Flathub repository and install the required KDE runtime and SDK.
 
 ```bash
-flatpak-builder --user --install --force-clean build-dir packaging/flatpak/manifest.json
-flatpak run com.rectifex.GlobalScreener           # Launch GUI
-flatpak run --command=rectifex-cli com.rectifex.GlobalScreener --help  # Invoke CLI
+# Add the Flathub remote repository (for the current user)
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+# Install the required KDE runtime and SDK (version 6.7)
+flatpak install --user -y flathub org.kde.Sdk//6.7 org.kde.Platform//6.7
+```
+> **Note:** The build environment may require specific workarounds if it does not support sandboxing features like `seccomp`. The provided manifest includes a `no-seccomp` option to accommodate such environments.
+
+### Build & Run
+
+With the prerequisites installed, you can build and run the application:
+
+```bash
+# Build and install the Flatpak package
+flatpak-builder --user --install --force-clean build-dir packaging/flatpak/com.rectifex.GlobalScreener.json
+
+# Launch the GUI
+flatpak run com.rectifex.GlobalScreener
+
+# Invoke the CLI
+flatpak run --command=rectifex-cli com.rectifex.GlobalScreener --help
 ```
 
 ## Data Source & Reliability Notes


### PR DESCRIPTION
This commit updates the project's documentation to be more accurate and complete.

- The `README.md` file is updated with a detailed "Flatpak Packaging" section. This includes prerequisites for installing the KDE SDK and Platform, and the correct build command using the canonical manifest file.
- A `LICENSE` file containing the standard MIT License text has been added to the project root to align with the license mentioned in the README.