### PR TITLE
fix(flatpak): Resolve missing urllib3 dependency in build

### DIFF
--- a/packaging/flatpak/com.rectifex.GlobalScreener.json
+++ b/packaging/flatpak/com.rectifex.GlobalScreener.json
@@ -20,7 +20,7 @@
                 "no-seccomp": true
             },
             "build-commands": [
-                "pip3 install --prefix=/app --no-index --find-links=packaging/flatpak/vendor -r requirements.txt",
+                "pip3 install --prefix=/app --no-index --find-links=packaging/flatpak/vendor -r packaging/flatpak/flatpak-requirements.txt",
                 "mkdir -p /app/src",
                 "cp -r app core cli /app/src/",
                 "install -Dm755 packaging/flatpak/run-app.sh /app/bin/run-app.sh",

--- a/packaging/flatpak/flatpak-requirements.txt
+++ b/packaging/flatpak/flatpak-requirements.txt
@@ -1,0 +1,48 @@
+# --- HTTP stack (Requests) ---
+requests==2.32.5
+urllib3==2.5.0
+certifi==2025.8.3
+idna==3.10
+
+# --- Numerics / Data ---
+numpy==2.3.3
+pandas==2.3.2
+python-dateutil==2.9.0.post0
+pytz==2025.2
+frozendict==2.4.4
+platformdirs==4.4.0
+typing_extensions==4.15.0
+six==1.17.0
+
+# --- Plotting ---
+matplotlib==3.10.6
+mplfinance==0.12.10b0
+cycler==0.12.1
+pillow==11.3.0
+packaging==25.0
+pyparsing==3.2.5
+fonttools==4.60.0
+contourpy==1.3.3
+kiwisolver==1.4.9
+
+# --- Networking / async ---
+websocket-client==1.8.0
+websockets==15.0.1
+multitasking==0.0.11
+cffi==2.0.0
+pycparser==2.23
+curl_cffi==0.7.3
+
+# --- Parsing / scraping ---
+lxml==6.0.2
+beautifulsoup4==4.13.5
+soupsieve==2.8
+
+# --- Finance / DB ---
+yfinance==0.2.66
+peewee==3.18.2
+
+# --- Qt UI (PyQt6) ---
+PyQt6==6.9.1
+PyQt6-Qt6==6.9.2
+PyQt6-sip==13.10.2


### PR DESCRIPTION
The Flatpak build was failing with a `ModuleNotFoundError` for `urllib3`. This was caused by a mismatch between the versions specified in the root `requirements.txt` and the actual package files vendored for the Flatpak build.

This commit introduces a dedicated `packaging/flatpak/flatpak-requirements.txt` file that contains the correct versions of the vendored dependencies.

The Flatpak manifest (`com.rectifex.GlobalScreener.json`) is updated to use this new requirements file, ensuring that all necessary packages are correctly installed within the Flatpak environment.