### PR TITLE
fix(flatpak): Resolve all build dependencies

### DIFF
--- a/packaging/flatpak/com.rectifex.GlobalScreener.json
+++ b/packaging/flatpak/com.rectifex.GlobalScreener.json
@@ -14,6 +14,20 @@
     ],
     "modules": [
         {
+            "name": "setuptools",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --prefix=/app --no-index --find-links=. ."
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz",
+                    "sha256": "f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
+                }
+            ]
+        },
+        {
             "name": "rectifex-global-screener",
             "buildsystem": "simple",
             "build-options": {


### PR DESCRIPTION
This commit resolves two critical issues that prevented the Flatpak application from building and running correctly:

1.  **Missing `urllib3` dependency:** The application would fail at runtime due to a `ModuleNotFoundError`. This was caused by a mismatch between the versions in `requirements.txt` and the vendored packages. This is fixed by introducing a dedicated `packaging/flatpak/flatpak-requirements.txt` with the correct versions and updating the build manifest to use it.

2.  **Missing `setuptools` build dependency:** The build process would fail when trying to install `peewee` from a source distribution (`.tar.gz`) because `setuptools` was not available. This is resolved by adding `setuptools` as a new, separate module in the Flatpak manifest, ensuring it is installed before the main application is built.

These changes ensure a clean, reproducible, and successful Flatpak build.