### PR TITLE
fix(flatpak): Correct setuptools source type to archive

### DIFF
--- a/packaging/flatpak/com.rectifex.GlobalScreener.json
+++ b/packaging/flatpak/com.rectifex.GlobalScreener.json
@@ -21,7 +21,7 @@
             ],
             "sources": [
                 {
-                    "type": "file",
+                    "type": "archive",
                     "url": "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz",
                     "sha256": "f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
                 }


### PR DESCRIPTION
The Flatpak build was failing because the `setuptools` source was defined with `type: file` instead of `type: archive`. This prevented the source tarball from being extracted, leading to a build error because `setup.py` could not be found.

This commit corrects the type to `archive`, ensuring the `flatpak-builder` extracts the source code before running the installation command. This resolves the final build-blocking issue.