### PR TITLE
fix(flatpak): Resolve all build dependencies and errors

### DIFF
--- a/packaging/flatpak/com.rectifex.GlobalScreener.json
+++ b/packaging/flatpak/com.rectifex.GlobalScreener.json
@@ -17,7 +17,7 @@
             "name": "setuptools",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --prefix=/app --no-index --find-links=. ."
+                "pip3 install --prefix=/app --ignore-installed --no-index --find-links=. ."
             ],
             "sources": [
                 {


### PR DESCRIPTION
This commit provides a comprehensive fix for a series of issues that prevented the Flatpak application from building and running correctly.

The fixes include:
1.  **Resolving `urllib3` `ModuleNotFoundError`**: A dedicated `packaging/flatpak/flatpak-requirements.txt` was created with package versions matching the vendored libraries. The manifest now correctly points to this file.
2.  **Resolving `setuptools` build dependency**: `setuptools` is now included as a separate module in the manifest to satisfy the build requirements of `peewee`.
3.  **Fixing source extraction**: The `setuptools` module source `type` is set to `archive` to ensure the source code is extracted before installation.
4.  **Fixing `Read-only file system` error**: The `--ignore-installed` flag has been added to the `pip` command for `setuptools`, which prevents it from trying to modify the read-only Flatpak SDK.

These changes collectively ensure a clean, reproducible, and successful Flatpak build.